### PR TITLE
Far Cry 6 load remover

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13299,4 +13299,15 @@
         <Description>AutoSplitter for Teeter Hero (by Nurufu)</Description>
         <Website>https://github.com/dcom365/TeeterHeroASL</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Far Cry 6</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Binslev/FC6LR/main/FC6%201.1.1.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Remover Available (By AlexYeahNot and Binslev)</Description>
+        <Website>https://github.com/Binslev/FC6LR</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Far Cry 6 was updated to version 1.1.1. I also tried to commit a load remover for FC6 version 1.1.0 a week ago, but that one is now obsolete. 

I hope I am adding my load remover correctly. Please let me know if I am doing something wrong, as this is my first time doing this.